### PR TITLE
Add a type to get type dynamic parameters

### DIFF
--- a/examples/merge-into-existing-json/pages/comments/comment.tsx
+++ b/examples/merge-into-existing-json/pages/comments/comment.tsx
@@ -2,6 +2,7 @@ import { NextFC } from "next";
 import Router from "next/router";
 import Link from "next/link";
 
+import { DynamicParameters } from "../../../../lib";
 import routes from "../../routes";
 
 type InitialProps = {
@@ -26,7 +27,7 @@ const Component: NextFC<InitialProps> = (props: InitialProps) => {
   );
 };
 
-type Query = ReturnType<typeof routes["comments/comment"]["getLinkProps"]>["href"]["query"];
+type Query = DynamicParameters<typeof routes["comments/comment"]>;
 Component.getInitialProps = ({ query }: { query: Query }) => {
   const userId = Number(query.userId);
   const commentId = Number(query.commentId);

--- a/examples/merge-into-existing-json/pages/users/user.tsx
+++ b/examples/merge-into-existing-json/pages/users/user.tsx
@@ -2,6 +2,7 @@ import { NextFC } from "next";
 import Router from "next/router";
 import Link from "next/link";
 
+import { DynamicParameters } from "../../../../lib";
 import routes from "../../routes";
 import { CommentModel } from "../../models/comment";
 
@@ -47,7 +48,7 @@ const Component: NextFC<InitialProps> = (props: InitialProps) => {
   );
 };
 
-type Query = ReturnType<typeof routes["users/user"]["getLinkProps"]>["href"]["query"];
+type Query = DynamicParameters<typeof routes["users/user"]>;
 Component.getInitialProps = ({ query }: { query: Query }) => {
   const userId = Number(query.userId);
 

--- a/examples/plain/pages/comments/comment.tsx
+++ b/examples/plain/pages/comments/comment.tsx
@@ -2,6 +2,7 @@ import { NextFC } from "next";
 import Router from "next/router";
 import Link from "next/link";
 
+import { DynamicParameters } from "../../../../lib";
 import routes from "../../routes";
 
 type InitialProps = {
@@ -26,7 +27,7 @@ const Component: NextFC<InitialProps> = (props: InitialProps) => {
   );
 };
 
-type Query = ReturnType<typeof routes["comments/comment"]["getLinkProps"]>["href"]["query"];
+type Query = DynamicParameters<typeof routes["comments/comment"]>;
 Component.getInitialProps = ({ query }: { query: Query }) => {
   const userId = Number(query.userId);
   const commentId = Number(query.commentId);

--- a/examples/plain/pages/users/user.tsx
+++ b/examples/plain/pages/users/user.tsx
@@ -2,6 +2,7 @@ import { NextFC } from "next";
 import Router from "next/router";
 import Link from "next/link";
 
+import { DynamicParameters } from "../../../../lib";
 import routes from "../../routes";
 import { CommentModel } from "../../models/comment";
 
@@ -47,7 +48,7 @@ const Component: NextFC<InitialProps> = (props: InitialProps) => {
   );
 };
 
-type Query = ReturnType<typeof routes["users/user"]["getLinkProps"]>["href"]["query"];
+type Query = DynamicParameters<typeof routes["users/user"]>;
 Component.getInitialProps = ({ query }: { query: Query }) => {
   const userId = Number(query.userId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Route } from "./route";
+export { Route, DynamicParameters } from "./route";

--- a/src/route.ts
+++ b/src/route.ts
@@ -93,3 +93,5 @@ export class Route<Parameters extends object = Record<string, number | string>> 
     return { src, dest };
   }
 }
+
+export type DynamicParameters<T extends Route> = ReturnType<T["getLinkProps"]>["href"]["query"];


### PR DESCRIPTION
# New Features
- Add DynamicParameters type to get a type of dynamic parameters


# Refactors
- Use `DynamicParameters` type instead of `ReturnType<T>` in examples
